### PR TITLE
Fix issue in variants_inr.rb seed file

### DIFF
--- a/db/samples/variants_inr.rb
+++ b/db/samples/variants_inr.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 Spree::Variant.all.each do |variant|
   variant.cost_currency = 'INR'
-  variant.price = variant.price * 10
+  variant.price = variant.cost_price * 10
   variant.save!
 end


### PR DESCRIPTION
There was an issue where price was not available and keyword `frozen_string_literal` was not present on the file. This has been fixed now.