### PR TITLE
Avoid duplicates in seeds

### DIFF
--- a/db/samples/prices_inr.rb
+++ b/db/samples/prices_inr.rb
@@ -5,5 +5,5 @@ Spree::Product.all.each do |product|
     currency: 'INR',
     amount: product.master.cost_price * 10,
     variant_id: product.master.id
-  )
+  ) unless product.prices.where(currency: 'INR').exists?
 end

--- a/db/samples/variants_inr.rb
+++ b/db/samples/variants_inr.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Spree::Variant.all.each do |variant|
+  next if variant.cost_currency == 'INR'
+
   variant.cost_currency = 'INR'
   variant.price = variant.cost_price * 10
   variant.save!


### PR DESCRIPTION
Some seeds were creating duplicates when ran multiple times.
This commit helps avoid that issue.