### PR TITLE
Add Seeds for Tax Rates and Zones

### DIFF
--- a/app/models/solidus_india/cgst_calculator.rb
+++ b/app/models/solidus_india/cgst_calculator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_dependency 'spree/calculator'
+
+module SolidusIndia
+  class CgstCalculator < Spree::Calculator
+    def compute_line_item(line_item)
+      calculate_rates(line_item)
+    end
+
+    def compute_shipment(shipment)
+      calculate_rates(shipment)
+    end
+
+    def compute_shipping_rate(shipping)
+      calculate_rates(shipping)
+    end
+
+    private
+
+    def calculate_rates(item)
+      tax_rate = Spree::TaxRate.find_by(name: 'CGST')
+      item.amount * tax_rate.amount
+    end
+  end
+end

--- a/app/models/solidus_india/igst_calculator.rb
+++ b/app/models/solidus_india/igst_calculator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_dependency 'spree/calculator'
+
+module SolidusIndia
+  class IgstCalculator < Spree::Calculator
+    def compute_line_item(line_item)
+      calculate_rates(line_item)
+    end
+
+    def compute_shipment(shipment)
+      calculate_rates(shipment)
+    end
+
+    def compute_shipping_rate(shipping)
+      calculate_rates(shipping)
+    end
+
+    private
+
+    def calculate_rates(item)
+      tax_rate = Spree::TaxRate.find_by(name: 'IGST')
+      item.amount * tax_rate.amount
+    end
+  end
+end

--- a/app/models/solidus_india/sgst_calculator.rb
+++ b/app/models/solidus_india/sgst_calculator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_dependency 'spree/calculator'
+
+module SolidusIndia
+  class SgstCalculator < Spree::Calculator
+    def compute_line_item(line_item)
+      calculate_rates(line_item)
+    end
+
+    def compute_shipment(shipment)
+      calculate_rates(shipment)
+    end
+
+    def compute_shipping_rate(shipping)
+      calculate_rates(shipping)
+    end
+
+    private
+
+    def calculate_rates(item)
+      tax_rate = Spree::TaxRate.find_by(name: 'SGST')
+      item.amount * tax_rate.amount
+    end
+  end
+end

--- a/db/samples/tax_rates_and_zone.rb
+++ b/db/samples/tax_rates_and_zone.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+country = Spree::Country.find_by(iso: 'IN')
+
+zone = Spree::Zone.find_or_create_by!(
+  name: 'India',
+  description: 'Taxes applied in the Indian Region',
+)
+
+Spree::ZoneMember.find_or_create_by!(
+  zoneable_type: 'Spree::Country',
+  zoneable_id: country.id,
+  zone_id: zone.id
+)
+
+tax_category_igst = Spree::TaxCategory.find_or_create_by!(
+  name: 'IGST',
+  description: 'Integrated Goods and Services Taxes',
+  tax_code: 'igst'
+)
+
+if tax_category_igst.tax_rates.pluck(:name).exclude?('IGST')
+  tax_rate_igst = Spree::TaxRate.find_or_create_by!(
+    name: 'IGST',
+    zone_id: zone.id,
+    amount: 0.18,
+    included_in_price: false,
+    show_rate_in_label: true,
+    level: 'item',
+    calculator: SolidusIndia::IgstCalculator.new
+  )
+
+  Spree::TaxRateTaxCategory.find_or_create_by!(
+    tax_rate_id: tax_rate_igst.id,
+    tax_category_id: tax_category_igst.id
+  )
+end
+
+tax_category_gst = Spree::TaxCategory.find_or_create_by!(
+  name: 'CGST + SGST',
+  description: 'Central and State Goods and Services Taxes',
+  tax_code: 'cgst-sgst'
+)
+
+if tax_category_gst.tax_rates.pluck(:name).exclude?('CGST')
+  tax_rate_cgst = Spree::TaxRate.find_or_create_by!(
+    name: 'CGST',
+    zone_id: zone.id,
+    amount: 0.09,
+    included_in_price: false,
+    show_rate_in_label: true,
+    level: "item",
+    calculator: SolidusIndia::CgstCalculator.new
+  )
+
+  Spree::TaxRateTaxCategory.find_or_create_by!(
+    tax_rate_id: tax_rate_cgst.id,
+    tax_category_id: tax_category_gst.id
+  )
+end
+
+if tax_category_gst.tax_rates.pluck(:name).exclude?('SGST')
+  tax_rate_sgst = Spree::TaxRate.find_or_create_by!(
+    name: 'SGST',
+    zone_id: zone.id,
+    amount: 0.09,
+    included_in_price: false,
+    show_rate_in_label: true,
+    level: "item",
+    calculator: SolidusIndia::SgstCalculator.new
+  )
+
+  Spree::TaxRateTaxCategory.find_or_create_by!(
+    tax_rate_id: tax_rate_sgst.id,
+    tax_category_id: tax_category_gst.id
+  )
+end

--- a/db/samples/update_products_with_tax_category.rb
+++ b/db/samples/update_products_with_tax_category.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+tax_category = Spree::TaxCategory.find_by(name: 'IGST')
+
+if tax_category.present?
+  Spree::Product.all.each do |product|
+    product.update(tax_category: tax_category)
+  end
+else
+  Rails.logger 'IGST TaxCategory not found, update the products manually after ensuring the TaxCategory has been created'
+end


### PR DESCRIPTION
This commit adds seeds for Indian Tax rates and zones. It creates tax categories with these tax rates.

The created tax_categories are applied to products so that taxes can be processed during the order calculation by the tax calculators added in this commit.