### PR TITLE
Modify the solidus_core requirement in gemspec

### DIFF
--- a/solidus_india.gemspec
+++ b/solidus_india.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
+  spec.add_dependency 'solidus_core', ['>= 2.2', '< 4']
   spec.add_dependency 'solidus_support', '~> 0.5'
 
   spec.add_development_dependency 'solidus_dev_support', '~> 2.5'


### PR DESCRIPTION
Modified the solidus_core requirement from 2.0.0 to 2.2.

This change has been made because the Tax Calculators are written to support item level tax calculations present from Solidus 2.2.